### PR TITLE
Advanced formatting improvements

### DIFF
--- a/mods/advanced-formatting.js
+++ b/mods/advanced-formatting.js
@@ -163,8 +163,11 @@ function get_random(length=4){
 
 /**
  * Add a before and after string to the selected part of the text area
- * @param beforeSelection the string to put at the start of selection
- * @param afterSelection the string to put at the end of selection
+ * @param {string} beforeSelection the string to put at the start of selection
+ * @param {string} afterSelection the string to put at the end of selection
+ * @param {boolean} tagEverySelectedLine for if beforeSelection and afterSelection are applied to each line of the selection
+ * @param {boolean} startAtBeginningOfLine for if beforeSelection is only applied to the start of a line regardless of selection
+ * @param {string} initialTag the string to put before start of selection
  */
 function writeToTextarea(beforeSelection, afterSelection, tagEverySelectedLine = false, startAtBeginningOfLine = false, initialTag = null){
     const textarea = document.querySelector("textarea");
@@ -455,6 +458,9 @@ function addEmotePickerButton(){
  * @param {string} openTag that appears before selection
  * @param {string} endTag that appears after selection
  * @param {string} title for button tooltip
+ * @param {boolean} tagEverySelectedLine should tags be applied to every selected line
+ * @param {boolean} startAtBeginningOfLine should open tags default to begining of line regardless of selection
+ * @param {string} initialTag that appears before selected lines
  * @returns {DOM} list item
  */
 function createSpecialFormattingbutton(buttonDisplayClass, openTag, endTag, title, tagEverySelectedLine = false, startAtBeginningOfLine = false, initialTag = null){

--- a/mods/advanced-formatting.js
+++ b/mods/advanced-formatting.js
@@ -175,12 +175,16 @@ function writeToTextarea(beforeSelection, afterSelection, tagEverySelectedLine =
     const end = textarea.selectionEnd;
 
     if (startAtBeginningOfLine) {
-      let newStart = textarea.value.lastIndexOf(`\n`, start);
-      if (newStart === -1) {
-        start = 0;
-      } else {
-        start = newStart + 1;
-      }
+      let offset = 0;
+      do {
+        let newStart = textarea.value.lastIndexOf(`\n`, start - offset);
+        if (newStart === -1) {
+          start = 0;
+        } else {
+          start = newStart + 1;
+        }
+        offset++;
+      } while (start > end);
     }
 
     let changedText = "";

--- a/mods/advanced-formatting.js
+++ b/mods/advanced-formatting.js
@@ -192,11 +192,6 @@ function writeToTextarea(beforeSelection, afterSelection, tagEverySelectedLine =
           changedText += "\n";
         }
       });
-      // remove extraneous last newline char
-      console.log(JSON.stringify(changedText));
-      changedText.replace(/\n$/, "");
-      console.log(JSON.stringify(changedText));
-
     } else {
       changedText = beforeSelection + textarea.value.substring(start, end) + afterSelection;
     }

--- a/mods/advanced-formatting.js
+++ b/mods/advanced-formatting.js
@@ -63,20 +63,20 @@ let DRAG_START_POS = {x:0, y:0};
 */
 let SIMULATED_FORMAT_BUTTON;
 /* Definitions for new formatters
-* [keystring (as per fa-icons), start tag, end tag, title, tag every selected line, initial tag] */
+* [keystring (as per fa-icons), start tag, end tag, title, tag every selected line boolean, start at beginning of line boolean, initial tag] */
 const FORMATTERS = [
-    ["header", "# ", "", chrome.i18n.getMessage("header"), true],
+    ["header", "# ", "", chrome.i18n.getMessage("header"), true, true],
     ["window-minimize", "", `
 ***
 `, chrome.i18n.getMessage("horizontal_line")],
-    ["quote-right", "> ", "", chrome.i18n.getMessage("block_quote"), true],
+    ["quote-right", "> ", "", chrome.i18n.getMessage("block_quote"), true, true],
     ["file-code-o", "`", "`", chrome.i18n.getMessage("inline_code"), true],
     ["th-large", `a | a
 ---|---
 x | x
 y | y
 `, "", chrome.i18n.getMessage("table")],
-    ["shield", ">> ", "", chrome.i18n.getMessage("spoiler"), true, "> Spoiler"],
+    ["shield", ">> ", "", chrome.i18n.getMessage("spoiler"), true, true, "> Spoiler"],
     ["list-ol", "1. ", "", chrome.i18n.getMessage("number_list")]
 ];
 /* default values - don't change these */
@@ -166,10 +166,20 @@ function get_random(length=4){
  * @param beforeSelection the string to put at the start of selection
  * @param afterSelection the string to put at the end of selection
  */
-function writeToTextarea(beforeSelection, afterSelection, tagEverySelectedLine, initialTag){
+function writeToTextarea(beforeSelection, afterSelection, tagEverySelectedLine = false, startAtBeginningOfLine = false, initialTag = null){
     const textarea = document.querySelector("textarea");
-    const start = textarea.selectionStart;
+    let start = textarea.selectionStart;
     const end = textarea.selectionEnd;
+
+    if (startAtBeginningOfLine) {
+      let newStart = start.lastIndexOf(`\n`, start);
+      if (newStart === -1) {
+        start = 0;
+      } else {
+        start = newStart + 1;
+      }
+    }
+
     let changedText = "";
     if (tagEverySelectedLine) {
       const selectedText = textarea.value.substring(start, end);
@@ -452,10 +462,10 @@ function addEmotePickerButton(){
  * @param {string} title for button tooltip
  * @returns {DOM} list item
  */
-function createSpecialFormattingbutton(buttonDisplayClass, openTag, endTag, title, tagEverySelectedLine = false, initialTag = null){
+function createSpecialFormattingbutton(buttonDisplayClass, openTag, endTag, title, tagEverySelectedLine = false, startAtBeginningOfLine = false, initialTag = null){
     const li = document.createElement("li");
     li.innerHTML = `<i class='fa fa-${buttonDisplayClass}'></i>`;
-    li.addEventListener("click", () => {writeToTextarea(openTag, endTag, tagEverySelectedLine, initialTag);});
+    li.addEventListener("click", () => {writeToTextarea(openTag, endTag, tagEverySelectedLine, startAtBeginningOfLine, initialTag);});
     li.title = title;
     li.setAttribute("tabindex", "-1");
     li.setAttribute("data-format", buttonDisplayClass);

--- a/mods/advanced-formatting.js
+++ b/mods/advanced-formatting.js
@@ -175,7 +175,7 @@ function writeToTextarea(beforeSelection, afterSelection, tagEverySelectedLine =
     const end = textarea.selectionEnd;
 
     if (startAtBeginningOfLine) {
-      let newStart = start.lastIndexOf(`\n`, start);
+      let newStart = textarea.value.lastIndexOf(`\n`, start);
       if (newStart === -1) {
         start = 0;
       } else {


### PR DESCRIPTION
I finally started using this extension after these recent forum updates ( _Nice work btw_ ), and I started investigating the modifications. I tried out the advanced formatting mod, but quickly saw that the additional buttons didn't behave the way I would expect.

This is the missing behavior I would expect:
- **Should allow multiple lines to be selected and applied to**
  - Header Button
  - Inline Code Button
  - Quote Button
  - Spoiler Button
  - Numbered List Button (TODO: Not addressed)

- **Should only apply to the start of a line if a selection is done**
  - Header Button
  - Quote Button
  - Spoiler Button

I have gotten all of that working with the mentioned buttons other than the Numbered List button. That one will require a less generalized function that will increment with each additional selected line. I will leave this pull request as draft until I, or someone else, finishes that aspect.