### PR TITLE
Activate the add theme button for the standard theme

### DIFF
--- a/options/theme-machine.js
+++ b/options/theme-machine.js
@@ -52,7 +52,7 @@ function _restoreThemes() {
         _colorLi.value = vt[index].colorLi;
         _colorAc.value = vt[index].colorAc;
       } else {
-        addTheme.disabled = true;
+        addTheme.disabled = false;
         removeTheme.disabled = true;
         editBtn.disabled = true;
         moveLeft.disabled = true;
@@ -86,7 +86,7 @@ function _selectTheme(event) {
         if (!name.startsWith("vfm_")) {
           chrome.storage.sync.set({ VFM_CURRENT_THEME: vct });
           toggleEdit.style.display = "none";
-          addTheme.disabled = true;
+          addTheme.disabled = false;
           removeTheme.disabled = true;
           editBtn.disabled = true;
           moveLeft.disabled = true;
@@ -133,13 +133,13 @@ function _addTheme() {
       const epoch = "vfm_" + Date.now();
       vt.push({
         themeName: epoch,
-        colorBg: vct.colors.colorBg,
-        colorFg: vct.colors.colorFg,
-        colorHi: vct.colors.colorHi,
-        colorCo: vct.colors.colorCo,
-        colorDd: vct.colors.colorDd,
-        colorLi: vct.colors.colorLi,
-        colorAc: vct.colors.colorAc,
+        colorBg: vct.colors.colorBg || "#ffffff",
+        colorFg: vct.colors.colorFg || "#000000",
+        colorHi: vct.colors.colorHi || "#c91106",
+        colorCo: vct.colors.colorCo || "#4c70f0",
+        colorDd: vct.colors.colorDd || "#ffffff",
+        colorLi: vct.colors.colorLi || "#4c70f0",
+        colorAc: vct.colors.colorAc || "#3b57bb",
       });
       chrome.storage.sync.set({ VFM_THEMES: vt }, function () {
         const btn = document.createElement("button");

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -258,8 +258,15 @@ function activateTheme() {
           chrome.runtime.sendMessage({ message: "options apply theme" });
         });
       } else {
-        sendToTabs("update theme");
-        chrome.runtime.sendMessage({ message: "options apply theme" });
+        // clear out colors when using standard theme
+        let co = vct.colors;
+        for (color in co) {
+          co[color] = ""
+        }
+        chrome.storage.sync.set({ VFM_CURRENT_THEME: vct }, () => {
+          sendToTabs("update theme");
+          chrome.runtime.sendMessage({ message: "options apply theme" });
+        });
       }
     }
   );


### PR DESCRIPTION
A more simplified change similar to PR #44, but now it only activates the add theme button on the standard theme and doesn't change other aspects of the standard theme implementation.