### PR TITLE
Maybe fixed emotes popup visibility issue

### DIFF
--- a/mods/advanced-formatting.js
+++ b/mods/advanced-formatting.js
@@ -471,7 +471,7 @@ function createEmotePicker() {
       box.appendChild(makeEmoteButton(emoteName, emoteUrl));
     }
   }
-  document.body.appendChild(box);
+  document.querySelector(".composer").appendChild(box);
 }
 
 /**


### PR DESCRIPTION
Not sure if this is all that needs to be done to fix the emotes picker popup in the advanced formatting mod.

I noticed that the emoji picker modal moved to the `.composer` div when zen mode was active and that the toolbar customization modal was also under the `.composer` div. Since the toolbar customization was still visible in zen and regular modes, I tried adding the emotes picker to the `.composer` div as well and it seems to work fine.

Let me know if that isn't a good fix. I am not sure about the extent of the issues with the advanced formatting mod, so this is the best I could do for now.